### PR TITLE
Cleaned up ReactHardwareComponent

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     React$Element: true,
   },
   rules: {
+    'object-curly-spacing': [2, 'never'],
     'react/jsx-uses-react': 2,
   },
 };

--- a/examples/webspeech/server.js
+++ b/examples/webspeech/server.js
@@ -15,7 +15,8 @@ const compiler = webpack({
   },
   module: {
     loaders: [
-      { test: /\.js$/,
+      {
+        test: /\.js$/,
         loader: require.resolve('babel-loader'),
         exclude: /node_modules/,
         query: {presets: ['react', 'es2015']},
@@ -78,4 +79,3 @@ new http.createServer((req, res) => {
 }).listen(9000, '127.0.0.1', () => {
   console.log('Speech recognizer webpack on localhost:8000');
 });
-

--- a/src/__tests__/HardwareManager-test.js
+++ b/src/__tests__/HardwareManager-test.js
@@ -18,7 +18,8 @@ describe('HardwareManager', () => {
       expect(() => {
         validatePayloadForPin(
           {board: hw, readers: []},
-          { pin: 0,
+          {
+            pin: 0,
             value: 255,
             mode: 'DIGITAL',
           }
@@ -36,7 +37,8 @@ describe('HardwareManager', () => {
       expect(() => {
         validatePayloadForPin(
           {board: hw, readers: []},
-          { pin: 0,
+          {
+            pin: 0,
             value: 255,
             mode: 'ANALOG',
           }
@@ -54,7 +56,8 @@ describe('HardwareManager', () => {
       expect(() => {
         validatePayloadForPin(
           {board: hw, readers: []},
-          { pin: 17,
+          {
+            pin: 17,
             value: 255,
             mode: 'PWM',
           }
@@ -146,4 +149,3 @@ describe('HardwareManager', () => {
     });
   });
 });
-

--- a/src/__tests__/ReactHardwareComponent-test.js
+++ b/src/__tests__/ReactHardwareComponent-test.js
@@ -4,8 +4,18 @@ import ReactHardwareComponent from '../ReactHardwareComponent';
 import ReactHardwareReconcileTransaction from '../ReactHardwareReconcileTransaction';
 
 describe('ReactHardwareComponent', () => {
+  it('should warn if it gets an unknown type', () => {
+    spyOn(console, 'error');
+    new ReactHardwareComponent({type: 'foo'}); // eslint-disable-line no-new
+    expect(console.error).toHaveBeenCalledWith(
+      'Warning: Attempted to render an unsupported generic component "foo". ' +
+      'Must be "pin" or "container".'
+    );
+
+  });
+
   xdescribe('mountComponent', () => {
-    it('should mount component', function() {
+    it('should mount component', () => {
       const willMount = jasmine.createSpy();
       const didMount = jasmine.createSpy();
       class Component extends React.Component { // eslint-disable-line
@@ -27,53 +37,41 @@ describe('ReactHardwareComponent', () => {
 
   describe('receiveComponent', function() {
     let gen;
-    beforeEach(function() {
-      const NodeStub = function(initialProps) {
-        this._currentElement = {props: initialProps};
-        this._rootNodeID = 'test';
-      };
-      NodeStub.prototype = new ReactHardwareComponent({
-        validAttributes: {
-          pin: true,
-          value: true,
-        },
-      });
-
-      Object.assign(NodeStub.prototype, ReactHardwareComponent.Mixin);
-
-      gen = function(props) {
-        return new NodeStub(props);
+    beforeEach(() => {
+      gen = function(type, props) {
+        const component = new ReactHardwareComponent({type, props});
+        component._rootNodeID = 'test';
+        return component;
       };
     });
 
-    it('should receive component', function() {
+    it('should receive component', () => {
       spyOn(HardwareManager, 'validatePayloadForPin');
       spyOn(HardwareManager, 'setPayloadForPin');
       const transaction = new ReactHardwareReconcileTransaction();
 
-      const inst = gen({pin: 13, value: 255});
+      const inst = gen('pin', {pin: 13, value: 255});
       expect(inst._currentElement.props.pin).toBe(13);
       expect(inst._currentElement.props.value).toBe(255);
 
-      inst.receiveComponent(gen({pin: 13, value: 0})._currentElement, transaction, {});
+      inst.receiveComponent(gen('pin', {pin: 13, value: 0})._currentElement, transaction, {});
 
       expect(inst._currentElement.props.pin).toBe(13);
       expect(inst._currentElement.props.value).toBe(0);
     });
 
-    it('should warn if attempting to change pin', function() {
+    it('should warn if attempting to change pin', () => {
       const transaction = new ReactHardwareReconcileTransaction();
 
-      const inst = gen({pin: 13, value: 255});
+      const inst = gen('pin', {pin: 13, value: 255});
       expect(_ => {
-        inst.receiveComponent(gen({pin: 14, value: 255})._currentElement, transaction, {});
+        inst.receiveComponent(gen('pin', {pin: 14, value: 255})._currentElement, transaction, {});
       }).toThrow(
         new Error(
-          'A mounted component cannot be mounted into a new Pin. The `pin` ' + 
-          'attribute is immutable. Check the render function of undefined.'
+          'A mounted component cannot be mounted into a new Pin. The `pin` ' +
+          'attribute is immutable.'
         )
       );
     });
   });
 });
-

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -10,14 +10,10 @@
  **/
 import React from 'react';
 
-export const CONTAINER_KEY = '__container';
-export const CONTAINER_VALUE = 'isContainer';
-const containerProp = {[CONTAINER_KEY]: CONTAINER_VALUE};
-
 class Container extends React.Component {
   render() {
     return (
-      <container {...containerProp}>
+      <container>
         {this.props.children}
       </container>
     );
@@ -27,4 +23,3 @@ class Container extends React.Component {
 Container.displayName = 'Container';
 
 export default Container;
-


### PR DESCRIPTION
* checks if the native component is supported, warns otherwise.  
  `<foo />` will warn. `<pin />` will not.
  Currently only `pin` and `container` is available
  Not sure if I should check in `receiveComponent` too.
* Added different view configs for the components.
* cleaned up the test a little bit.
* removed the possibility to use any native component name.  
  e.g `<foo />` and `<pin />` would act the same, but not anymore.
