### PR TITLE
Fix undefined props in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ class Application extends React.Component {
 }
 
 var PORT = '/dev/tty.usbmodem1411';
-ReactHardware.render(<Application />, PORT);
+ReactHardware.render(<Application interval={1000} />, PORT);
 ```
 
 While this is unquestionably more code than it’s Johnny-Five or Sketch
@@ -76,6 +76,9 @@ class FlashingLed extends React.Component {
     this.state = {
       value: 0,
       _timer: null,
+    };
+    this.defaultProps = {
+      interval: 1000,
     };
   }
 


### PR DESCRIPTION
In the example code snippets in the README, some components reference their given props. But, no props are given, so these prop values are undefined. The specific prop value that is missing from the *Application* and *FlashingLed* components is the "interval" prop.

In this commit, I provide the interval prop to the Application component in the first example at the time that it's rendered, and I gave the interval prop a default value in the FlashingLed component to prevent unnecessary repetition in the second example.

TLDR: I gave *Application* and *FlashingLed* an interval prop value, because it'd be undefined otherwise.