### PR TITLE
Implements support for Arduino internal pull-up on buttons

### DIFF
--- a/flow-typed/jsx-intrinsics.js
+++ b/flow-typed/jsx-intrinsics.js
@@ -10,6 +10,7 @@ declare type $JSXIntrinsics = {
         | 'INPUT'
         | 'OUTPUT'
         | 'ANALOG'
+        | 'PULLUP'
         | 'PWM'
         | 'SERVO'
         | 'SHIFT'

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     "url": "https://github.com/iamdustan/react-hardware/issues"
   },
   "homepage": "https://github.com/iamdustan/react-hardware",
+  "jest": {
+    "resetMocks": true,
+    "roots": ["src"]
+  },
   "dependencies": {
     "firmata": "^2.0.0",
     "invariant": "2.2.4",
@@ -61,9 +65,10 @@
     "eslint-plugin-react": "^7.12.4",
     "flow-bin": "^0.94.0",
     "jest": "^24.1.0",
-    "prettier": "^1.16.4",
     "mock-firmata": "0.2.0",
-    "react-devtools": "^3.6.1"
+    "prettier": "^1.16.4",
+    "react-devtools": "^3.6.1",
+    "react-test-renderer": "^16.8.6"
   },
   "prettier": {
     "bracketSpacing": false,

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -2,6 +2,7 @@
  * ReactHardware <Button /> component.
  *
  * <Button
+ *   internalPullup
  *   onDown={() => console.log('Button pressed')}
  *   onUp={() => console.log('Button depressed')}
  *   onChange={({value}) => console.log('Button changes to %s', value)}
@@ -17,11 +18,15 @@ type Props = {
   onChange: ?(event: HardwareEvent) => any,
   onDown: ?(event: HardwareEvent) => any,
   onUp: ?(event: HardwareEvent) => any,
+  internalPullup: ?boolean,
 };
 
 class Button extends React.Component<Props> {
-  onRead = (value: number) => {
-    const {onDown, onUp, onChange} = this.props;
+  onRead = (observedValue: number) => {
+    const {onDown, onUp, onChange, internalPullup} = this.props;
+
+    const value = internalPullup ? +!observedValue : observedValue;
+
     if (value === 1 && typeof onDown === 'function') {
       onDown({value, type: 'down'});
     } else if (value === 0 && typeof onUp === 'function') {
@@ -34,7 +39,13 @@ class Button extends React.Component<Props> {
   };
 
   render() {
-    return <pin pin={this.props.pin} onRead={this.onRead} mode={'INPUT'} />;
+    return (
+      <pin
+        pin={this.props.pin}
+        onRead={this.onRead}
+        mode={this.props.internalPullup ? 'PULLUP' : 'INPUT'}
+      />
+    );
   }
 }
 

--- a/src/components/__tests__/Button-test.js
+++ b/src/components/__tests__/Button-test.js
@@ -10,46 +10,49 @@ const props = {
   internalPullup: false,
 };
 
-let component;
-let view;
-
 describe('Standard input', () => {
-  beforeEach(() => {
-    component = TestRenderer.create(<Button {...props} />);
-    view = component.toJSON();
-  });
-
   it('should call onDown when the button is pressed', () => {
+    const component = TestRenderer.create(<Button {...props} />);
+    let view = component.toJSON();
+
     view.props.onRead(1);
     view = component.toJSON();
+
     expect(props.onDown).toBeCalledWith({type: "down", value: 1});
     expect(props.onUp).not.toBeCalled();
   });
 
   it('should call onUp when the button is raised', () => {
+    const component = TestRenderer.create(<Button {...props} />);
+    let view = component.toJSON();
+
     view.props.onRead(0);
     view = component.toJSON();
+
     expect(props.onDown).not.toBeCalled();
     expect(props.onUp).toBeCalledWith({type: "up", value: 0});
   });
 });
 
 describe('Internal Pull-Up Set', () => {
-    beforeEach(() => {
-      component = TestRenderer.create(<Button {...props} internalPullup />);
-      view = component.toJSON();
-    });
-  
     it('should call onDown when the button is pressed', () => {
+      const component = TestRenderer.create(<Button {...props} internalPullup />);
+      let view = component.toJSON();
+
       view.props.onRead(0);
       view = component.toJSON();
+
       expect(props.onDown).toBeCalledWith({type: "down", value: 1});
       expect(props.onUp).not.toBeCalled();
     });
   
     it('should call onUp when the button is raised', () => {
+      const component = TestRenderer.create(<Button {...props} internalPullup />);
+      let view = component.toJSON();
+
       view.props.onRead(1);
       view = component.toJSON();
+
       expect(props.onDown).not.toBeCalled();
       expect(props.onUp).toBeCalledWith({type: "up", value: 0});
     });

--- a/src/components/__tests__/Button-test.js
+++ b/src/components/__tests__/Button-test.js
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import Button from '../Button';
+import TestRenderer from 'react-test-renderer';
+
+const props = {
+  pin: 6,
+  onChange: jest.fn(),
+  onDown: jest.fn(),
+  onUp: jest.fn(),
+  internalPullup: false,
+};
+
+let component;
+let view;
+
+describe('Standard input', () => {
+  beforeEach(() => {
+    component = TestRenderer.create(<Button {...props} />);
+    view = component.toJSON();
+  });
+
+  it('should call onDown when the button is pressed', () => {
+    view.props.onRead(1);
+    view = component.toJSON();
+    expect(props.onDown).toBeCalledWith({type: "down", value: 1});
+    expect(props.onUp).not.toBeCalled();
+  });
+
+  it('should call onUp when the button is raised', () => {
+    view.props.onRead(0);
+    view = component.toJSON();
+    expect(props.onDown).not.toBeCalled();
+    expect(props.onUp).toBeCalledWith({type: "up", value: 0});
+  });
+});
+
+describe('Internal Pull-Up Set', () => {
+    beforeEach(() => {
+      component = TestRenderer.create(<Button {...props} internalPullup />);
+      view = component.toJSON();
+    });
+  
+    it('should call onDown when the button is pressed', () => {
+      view.props.onRead(0);
+      view = component.toJSON();
+      expect(props.onDown).toBeCalledWith({type: "down", value: 1});
+      expect(props.onUp).not.toBeCalled();
+    });
+  
+    it('should call onUp when the button is raised', () => {
+      view.props.onRead(1);
+      view = component.toJSON();
+      expect(props.onDown).not.toBeCalled();
+      expect(props.onUp).toBeCalledWith({type: "up", value: 0});
+    });
+  });

--- a/src/firmata/HardwareManager.js
+++ b/src/firmata/HardwareManager.js
@@ -27,6 +27,7 @@ const FIRMATA_COMMUNICATION_METHOD = {
   '6': 'i2c', // i2c
   '7': 'UNKNOWN', // onewire
   '8': 'UNKNOWN', // stepper
+  '11': 'digital', // input, internal pull-up
   '16': 'UNKNOWN', // unknown
   '127': 'IGNORE', // ignore
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,6 +3852,11 @@ react-is@^16.8.1:
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
 
+react-is@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
 react-reconciler@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.20.2.tgz#f72fe0329d579371f253719080e7d090262330a9"
@@ -3860,6 +3865,16 @@ react-reconciler@^0.20.2:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.4"
+
+react-test-renderer@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.6.tgz#188d8029b8c39c786f998aa3efd3ffe7642d5ba1"
+  integrity sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.13.6"
 
 react@16.8.4:
   version "16.8.4"
@@ -4174,6 +4189,14 @@ sax@^1.2.4:
 scheduler@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.4.tgz#8fef05e7a3580c76c0364d2df5e550e4c9140298"
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
### What
This commit allows users to cause the Arduino to leverage the built-in pull-up resistors such that they can remove the need for a separate pull-down resistor.

It also implements unit tests for the `Button` component to validate no regressions.

### Why
One less component to put on a breadboard.

### Supporting Documents
Leveraging the internal pull-up: https://www.arduino.cc/en/Tutorial/DigitalInputPullup
Standard button implementation: https://www.arduino.cc/en/tutorial/button